### PR TITLE
Explicitly specify Python 3 interpreter

### DIFF
--- a/rpm/ros-humble-pcl-conversions.spec
+++ b/rpm/ros-humble-pcl-conversions.spec
@@ -64,6 +64,7 @@ mkdir -p .obj-%{_target_platform} && cd .obj-%{_target_platform}
 %if !0%{?with_tests}
     -DBUILD_TESTING=OFF \
 %endif
+    -DPython3_EXECUTABLE="%{__python3}" \
     ..
 
 %make_build


### PR DESCRIPTION
A recent change to RHEL 8 results in the Python 3.11 interpreter being present during this package build due to an indirect dependency. The find_package(Python3) search is discovering the newer interpreter and attempting to use it instead of the system's default interpreter, for which we've installed other dependencies.

This flag should force the find_package logic to use the system's default interpreter as it was doing before.